### PR TITLE
sepolicy: Allow minivold execute_no_trans

### DIFF
--- a/sepolicy/vold.te
+++ b/sepolicy/vold.te
@@ -13,6 +13,7 @@ allow vold self:capability { setgid setuid };
 # Vold can also run as minivold in the rootfs
 recovery_only(`
   allow vold rootfs:dir { add_name write };
+  allow vold rootfs:file execute_no_trans;
 ')
 
 # External storage


### PR DESCRIPTION
After assimilating minivold into /sbin/recovery, we need to allow the
minivold service (a symlink to the recovery binary) to transition from
the recovery to the vold domain.

Change-Id: I112e6d371a8da8fc55a06967852c869105190616